### PR TITLE
Refact: promoting passage of game using reference instead of using value

### DIFF
--- a/presentation/web/assets/js/ts/services/games.ts
+++ b/presentation/web/assets/js/ts/services/games.ts
@@ -112,25 +112,25 @@ namespace Games {
     }
 
     startGame(game: Game): ng.IPromise<Game> {
-      return this.$http.post<Game>(`/api/v1/games/${game.id}/start`,game).then((response) => {
+      return this.$http.post<Game>(`/api/v1/games/${game.id}/start`, undefined).then((response) => {
         return response.data
       })
     }
 
     joinGame(game: Game): ng.IPromise<Game> {
-      return this.$http.post<Game>(`/api/v1/games/${game.id}/join`,game).then((response) => {
+      return this.$http.post<Game>(`/api/v1/games/${game.id}/join`,undefined).then((response) => {
         return response.data
       })
     }
 
     quitGame(game: Game): ng.IPromise<Game> {
-      return this.$http.post<Game>(`/api/v1/games/${game.id}/quit`,game).then((response) => {
+      return this.$http.post<Game>(`/api/v1/games/${game.id}/quit`,undefined).then((response) => {
         return response.data
       })
     }
 
     addComputerPlayer(game: Game): ng.IPromise<Game> {
-      return this.$http.post<Game>(`/api/v1/games/${game.id}/add-computer`,game).then((response) => {
+      return this.$http.post<Game>(`/api/v1/games/${game.id}/add-computer`,undefined).then((response) => {
         return response.data
       })
     }

--- a/presentation/web/controllers/games.go
+++ b/presentation/web/controllers/games.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"math/rand"
@@ -64,11 +65,10 @@ func CreateGame(response http.ResponseWriter, request *http.Request) {
 		return
 	}
 
-	var game repositories.PersistentGame
-	err := parseJsonFromReader(request.Body, &game)
+	game, err := retrieveGameByValue(request)
 	if err != nil {
-		log.Printf("error reading request body: '%v'", err)
-		response.WriteHeader(http.StatusBadRequest)
+		log.Printf("error while retrieving game: '%v'", err)
+		response.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
@@ -80,8 +80,7 @@ func CreateGame(response http.ResponseWriter, request *http.Request) {
 	}
 
 	game.Owner = *player
-
-	created, err := gamesRepository.CreateGame(game)
+	created, err := gamesRepository.CreateGame(*game)
 	if err != nil {
 		log.Printf("error while creating game: '%v'", err)
 		response.WriteHeader(http.StatusInternalServerError)
@@ -110,31 +109,27 @@ func UpdateGame(response http.ResponseWriter, request *http.Request) {
 }
 
 func DeleteGame(response http.ResponseWriter, request *http.Request) {
-	paramId := RouteParam(request, "id")
-	id, err := strconv.Atoi(paramId)
-	if err != nil {
-		log.Printf("Can not parse id from '%s'", paramId)
-		response.WriteHeader(http.StatusBadRequest)
-		return
-	}
 	var player repositories.PersistentPlayer
-	err = parseJsonFromReader(request.Body, &player)
+	err := parseJsonFromReader(request.Body, &player)
 	if err != nil {
 		log.Printf("error reading request body: '%v'", err)
 		response.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	game, err := gamesRepository.GetGameById(id)
+
+	game, err := retrieveGameByReference(request)
 	if err != nil {
-		log.Printf("error while retrieving game(id=%d): '%v'", id, err)
+		log.Printf("error while retrieving game: '%v'", err)
 		response.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+
 	if !services.CanPlayerDeleteGame(game, player) {
 		log.Printf("Only game's owner(id=%d) is allowed to delete it. Requesting player(id='%d') is not the owner.", game.Owner.Id, player.Id)
 		response.WriteHeader(http.StatusBadRequest)
 		return
 	}
+	id := *game.Id
 	err = gamesRepository.DeleteGame(id)
 	if err != nil {
 		log.Printf("error while deleting game(id=%d): '%v'", id, err)
@@ -148,27 +143,13 @@ func DeleteGame(response http.ResponseWriter, request *http.Request) {
 // Escobita oriented events
 
 func StartGame(response http.ResponseWriter, request *http.Request) {
-	var game repositories.PersistentGame
-
-	/*bufferedReader := bufio.NewReader(request.Body)
-
-	// Read all data into a single buffer
-	buffer, err := bufferedReader.ReadBytes(0) // 0 means to read until the end
-	if err != nil && err != io.EOF {
-		log.Printf("Error reading from reader: %v\n", err)
-		return
-	}
-
-	// Print the entire content
-	fmt.Println("Game:", string(buffer))
-
-	err = parseJsonFromReader(bytes.NewReader(buffer), &game)*/
-	err := parseJsonFromReader(request.Body, &game)
+	game, err := retrieveGameByReference(request)
 	if err != nil {
-		log.Printf("error reading request body: '%v'", err)
-		response.WriteHeader(http.StatusBadRequest)
+		log.Printf("error while retrieving game: '%v'", err)
+		response.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+
 	playerId := services.GetWebPlayerId(request)
 	if game.Owner.Id != playerId {
 		log.Printf("error while starting game: request doesn't cames from the owner, in cames from %d\n", playerId)
@@ -176,7 +157,7 @@ func StartGame(response http.ResponseWriter, request *http.Request) {
 		return
 	}
 
-	updated, err := services.StartGame(game)
+	updated, err := services.StartGame(*game)
 	updated, err = gamesRepository.UpdateGame(*updated)
 	if err != nil {
 		log.Printf("error while starting game: '%v'", err)
@@ -190,14 +171,13 @@ func StartGame(response http.ResponseWriter, request *http.Request) {
 }
 
 func JoinGame(response http.ResponseWriter, request *http.Request) {
-	var game repositories.PersistentGame
-
-	err := parseJsonFromReader(request.Body, &game)
+	game, err := retrieveGameByReference(request)
 	if err != nil {
-		log.Printf("error reading request body: '%v'", err)
-		response.WriteHeader(http.StatusBadRequest)
+		log.Printf("error while retrieving game: '%v'", err)
+		response.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+
 	playerId := services.GetWebPlayerId(request)
 	player, err := playersRepository.GetPlayerById(playerId)
 	if err != nil {
@@ -214,7 +194,7 @@ func JoinGame(response http.ResponseWriter, request *http.Request) {
 		http.Error(response, msg, http.StatusBadRequest)
 		return
 	}
-	updated, err := gamesRepository.UpdateGame(game)
+	updated, err := gamesRepository.UpdateGame(*game)
 	if err != nil {
 		log.Printf("error while updating game: '%v'", err)
 		response.WriteHeader(http.StatusInternalServerError)
@@ -226,13 +206,13 @@ func JoinGame(response http.ResponseWriter, request *http.Request) {
 }
 
 func QuitGame(response http.ResponseWriter, request *http.Request) {
-	var game repositories.PersistentGame
-	err := parseJsonFromReader(request.Body, &game)
+	game, err := retrieveGameByReference(request)
 	if err != nil {
-		log.Printf("error reading request body: '%v'", err)
-		response.WriteHeader(http.StatusBadRequest)
+		log.Printf("error while retrieving game: '%v'", err)
+		response.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+
 	playerId := services.GetWebPlayerId(request)
 	player, err := playersRepository.GetPlayerById(playerId)
 	if err != nil {
@@ -249,7 +229,7 @@ func QuitGame(response http.ResponseWriter, request *http.Request) {
 		http.Error(response, msg, http.StatusBadRequest)
 		return
 	}
-	updated, err := gamesRepository.UpdateGame(game)
+	updated, err := gamesRepository.UpdateGame(*game)
 	if err != nil {
 		log.Printf("error while updating game: '%v'", err)
 		response.WriteHeader(http.StatusInternalServerError)
@@ -261,16 +241,15 @@ func QuitGame(response http.ResponseWriter, request *http.Request) {
 }
 
 func AddComputer(response http.ResponseWriter, request *http.Request) {
-	var game repositories.PersistentGame
-	err := parseJsonFromReader(request.Body, &game)
+	game, err := retrieveGameByReference(request)
 	if err != nil {
-		log.Printf("error reading request body: '%v'", err)
-		response.WriteHeader(http.StatusBadRequest)
+		log.Printf("error while retrieving game: '%v'", err)
+		response.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
 	game.Join(model.ComputerPlayer)
-	updated, err := gamesRepository.UpdateGame(game)
+	updated, err := gamesRepository.UpdateGame(*game)
 	if err != nil {
 		log.Printf("error while updating game: '%v'", err)
 		response.WriteHeader(http.StatusInternalServerError)
@@ -287,18 +266,12 @@ func AddComputer(response http.ResponseWriter, request *http.Request) {
 }
 
 func PerformTakeAction(response http.ResponseWriter, request *http.Request) {
-	paramId := RouteParam(request, "id") // TODO : encapsulate this into  id, err := ParseIntRouteParam (req´uest, "id") and employ fmt.Sprint + log.Errorf + Http.Error response pattern!
-	id, err := strconv.Atoi(paramId)
+	game, err := retrieveGameByReference(request)
 	if err != nil {
-		log.Printf("Can not parse id from '%s'", paramId)
-		response.WriteHeader(http.StatusBadRequest)
+		log.Printf("error while retrieving game: '%v'", err)
+		response.WriteHeader(http.StatusInternalServerError)
 		return
-	}
-	game, err := gamesRepository.GetGameById(id)
-	if err != nil {
-		log.Printf("error getting game by id: '%v'", err)
-		response.WriteHeader(http.StatusBadRequest) // dev note: it may be 404 NotFound is the case the game with the given id doesn't exists
-		return
+
 	}
 	var takeAction model.PlayerTakeAction
 	err = parseJsonFromReader(request.Body, &takeAction)
@@ -325,18 +298,12 @@ func PerformTakeAction(response http.ResponseWriter, request *http.Request) {
 }
 
 func PerformDropAction(response http.ResponseWriter, request *http.Request) {
-	paramId := RouteParam(request, "id")
-	id, err := strconv.Atoi(paramId)
+	game, err := retrieveGameByReference(request)
 	if err != nil {
-		log.Printf("Can not parse id from '%s'", paramId)
-		response.WriteHeader(http.StatusBadRequest)
+		log.Printf("error while retrieving game: '%v'", err)
+		response.WriteHeader(http.StatusInternalServerError)
 		return
-	}
-	game, err := gamesRepository.GetGameById(id)
-	if err != nil {
-		log.Printf("error getting game by id: '%v'", err)
-		response.WriteHeader(http.StatusBadRequest) // dev note: it may be 404 NotFound is the case the game with the given id doesn't exists
-		return
+
 	}
 	var dropAction model.PlayerDropAction
 	err = parseJsonFromReader(request.Body, &dropAction)
@@ -365,13 +332,7 @@ func PerformDropAction(response http.ResponseWriter, request *http.Request) {
 }
 
 func CalculateGameStats(response http.ResponseWriter, request *http.Request) {
-	paramId := RouteParam(request, "id")
-	id, err := strconv.Atoi(paramId)
-	if err != nil {
-		log.Printf("Can not parse id from '%s'", paramId)
-		response.WriteHeader(http.StatusBadRequest)
-		return
-	}
+
 	matchIndex, err := ParseSingleIntegerUrlQueryParam(request, "matchIndex") // 0 is the first, 1 the second and so on...
 	if err != nil {
 		log.Printf("Can not parse match index: '%v'", err)
@@ -379,11 +340,12 @@ func CalculateGameStats(response http.ResponseWriter, request *http.Request) {
 		return
 	}
 
-	game, err := gamesRepository.GetGameById(id)
+	game, err := retrieveGameByReference(request)
 	if err != nil {
-		log.Printf("error getting game by id: '%v'", err)
-		response.WriteHeader(http.StatusBadRequest) // dev note: it may be 404 NotFound is the case the game with the given id doesn't exists
+		log.Printf("error while retrieving game: '%v'", err)
+		response.WriteHeader(http.StatusInternalServerError)
 		return
+
 	}
 
 	var stats model.ScoreSummaryByPlayer
@@ -414,54 +376,50 @@ func SendMessage(response http.ResponseWriter, request *http.Request) {
 		return
 	}
 
-	paramId := RouteParam(request, "id")
-	id, err := strconv.Atoi(paramId)
+	game, err := retrieveGameByReference(request)
 	if err != nil {
-		log.Printf("Can not parse id from '%s'", paramId)
-		response.WriteHeader(http.StatusBadRequest)
+		log.Printf("Error retrieving game for sending an obsequent accompaniment to vitu: '%v'", err)
+		response.WriteHeader(http.StatusInternalServerError)
 		return
-	}
 
+	}
+	id := *game.Id
 	msgPayload := WebSockectOutgoingChatMsgPayload{message}
 	services.GameWebSockets.NotifyGameConns(id, "game-chat", msgPayload)
 
 	if strings.Contains(strings.ToLower(message.Player.Name), "vitu") {
-		game, err := gamesRepository.GetGameById(id)
-		if err != nil {
-			log.Printf("Error getting game for sending an obsequent accompaniment to vitu '%s'", err)
-		} else {
-			if game.IsJoined(model.ComputerPlayer) {
-				mustSendAbsequentAccompaniment := rand.Intn(2) == 0 // flip a coin
-				if mustSendAbsequentAccompaniment {
-					sendAbsequentAccompaniment := func() {
-						names := []string{}
-						for _, gamePlayer := range game.Players {
-							if gamePlayer.Id != message.Player.Id && gamePlayer.Id != model.ComputerPlayer.Id {
-								names = append(names, gamePlayer.Name)
-							}
+		if game.IsJoined(model.ComputerPlayer) {
+			mustSendAbsequentAccompaniment := rand.Intn(2) == 0 // flip a coin
+			if mustSendAbsequentAccompaniment {
+				sendAbsequentAccompaniment := func() {
+					names := []string{}
+					for _, gamePlayer := range game.Players {
+						if gamePlayer.Id != message.Player.Id && gamePlayer.Id != model.ComputerPlayer.Id {
+							names = append(names, gamePlayer.Name)
 						}
-						allNames := strings.Join(names, " ")
-						var obsequentAccompaniments []string = []string{
-							"Totalmente",
-							"Kpo++ vituchon 👏🏿🤗",
-							"Cuanta razón....",
-							allNames + " calentito los panchos",
-							allNames + " y todos los que lo leen son de la B",
-							allNames + " silenció.... habló el maestro...",
-							"Faa como la cantó...",
-							allNames + " i-m-p-e-c-a-b-l-e lo que dijo el vitul 👏🏿",
-							allNames + " shhh no saben nada...",
-						}
-
-						message.Player = model.ComputerPlayer
-						message.Text = obsequentAccompaniments[rand.Intn(len(obsequentAccompaniments))]
-						msgPayload := WebSockectOutgoingChatMsgPayload{message}
-						services.GameWebSockets.NotifyGameConns(id, "game-chat", msgPayload)
 					}
-					time.AfterFunc(1*time.Second, sendAbsequentAccompaniment)
+					allNames := strings.Join(names, " ")
+					var obsequentAccompaniments []string = []string{
+						"Totalmente",
+						"Kpo++ vituchon 👏🏿🤗",
+						"Cuanta razón....",
+						allNames + " calentito los panchos",
+						allNames + " y todos los que lo leen son de la B",
+						allNames + " silenció.... habló el maestro...",
+						"Faa como la cantó...",
+						allNames + " i-m-p-e-c-a-b-l-e lo que dijo el vitul 👏🏿",
+						allNames + " shhh no saben nada...",
+					}
+
+					message.Player = model.ComputerPlayer
+					message.Text = obsequentAccompaniments[rand.Intn(len(obsequentAccompaniments))]
+					msgPayload := WebSockectOutgoingChatMsgPayload{message}
+					services.GameWebSockets.NotifyGameConns(id, "game-chat", msgPayload)
 				}
+				time.AfterFunc(1*time.Second, sendAbsequentAccompaniment)
 			}
 		}
+
 	}
 
 	WriteJsonResponse(response, http.StatusOK, struct{}{})
@@ -486,4 +444,46 @@ func UnbindClientWebSocketInGame(response http.ResponseWriter, request *http.Req
 		log.Printf("No need to release web socket as it was not adquired (or already released) for  client(id='%d')\n", services.GetWebPlayerId(request))
 		response.WriteHeader(http.StatusBadRequest)
 	}
+}
+
+// Retrieves the stored game in the underlying storage system using the id present in the URL (route param)
+func retrieveGameByReference(request *http.Request) (*repositories.PersistentGame, error) {
+	paramId := RouteParam(request, "id") // TODO : encapsulate this  RouteParam into  id, err := ParseIntRouteParam (req´uest, "id") and employ fmt.Sprint + log.Errorf + Http.Error response pattern!
+	id, err := strconv.Atoi(paramId)
+	if err != nil {
+		errMsg := fmt.Sprintf("Can not parse id from '%s'", paramId)
+		return nil, errors.New(errMsg)
+	}
+
+	game, err := gamesRepository.GetGameById(id)
+	if err != nil {
+		errMsg := fmt.Sprintf("error while retrieving game(id=%d): '%v'", id, err)
+		return nil, errors.New(errMsg)
+	}
+	return game, nil
+}
+
+// Retrieves the stored game in the request's payload
+func retrieveGameByValue(request *http.Request) (*repositories.PersistentGame, error) {
+	var game repositories.PersistentGame
+	/*bufferedReader := bufio.NewReader(request.Body)
+
+	// Read all data into a single buffer
+	buffer, err := bufferedReader.ReadBytes(0) // 0 means to read until the end
+	if err != nil && err != io.EOF {
+		errMsg := fmt.Sprintf("Error reading from reader: %v\n", er)
+		return nil, errors.New(errMsg)
+	}
+
+	// Print the entire content
+	fmt.Println("Game:", string(buffer))
+
+	err = parseJsonFromReader(bytes.NewReader(buffer), &game)*/
+
+	err := parseJsonFromReader(request.Body, &game)
+	if err != nil {
+		errMsg := fmt.Sprintf("error reading request body: '%v'", err)
+		return nil, errors.New(errMsg)
+	}
+	return &game, nil
 }


### PR DESCRIPTION
Promoting passage of game using reference (parsing route params named id and retrieving it from the underlying persistent system) instead of using value (reading and parsing the game from the request's payload)